### PR TITLE
Di 23431 json filter to ngx filter converter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,11 @@
-import { JSONFilter, FieldType } from './json-filter';
+import { JSONFilter, FieldType, JSONRegularFilter } from './json-filter';
 import { FilterFactory } from './filters/filter-factory';
 import Filter from './filters/filter';
 import { SQLWhereParser } from './sql-where-parser';
 import { JSONFilterTransformer, NodeTransformer } from './json-filter-transformer';
 import esb, { Query } from 'elastic-builder';
 import { DynamoResultObject } from './filters/DynamoObjectResult';
+import { NGXFilterOperationFactory } from './ngx-filters/ngx-filter-factory';
 
 /**
  * Concat two JSON Filters by combining them into one
@@ -108,6 +109,15 @@ export function toDynamoDBQuery(
         return filter.toDynamoDBQuery(letterForMark, expressionAttributeNames, expressionAttributeValues, count);
     }
     throw new Error('jsonFilter is a mandatory parameter');
+}
+
+/**
+ * 
+ * @param filter - json regular filter 
+ * @returns the correspond NGX smart filter
+ */
+export function toNGXSmartFilter(filter: JSONRegularFilter){
+    return NGXFilterOperationFactory.create(filter)
 }
 
 export function filter<T>(

--- a/ngx-filters/ngx-filter-factory.ts
+++ b/ngx-filters/ngx-filter-factory.ts
@@ -1,0 +1,69 @@
+import { JSONRegularFilter } from "../json-filter"
+import { NGXFilterBeginsWithOperation, NGXFilterBetweenOperationFactory, NGXFilterContainsOperation, NGXFilterDueInOperation, NGXFilterEndsWithOperation, NGXFilterGreaterThanOperation, NGXFilterInTheLastOperation, NGXFilterIsEmptyOperation, NGXFilterIsEqualOperation, NGXFilterIsNotEmptyOperation, NGXFilterLessThanOperation, NGXFilterNotDueInOperation, NGXFilterNotEqualOperation, NGXFilterOnOperation, NGXFilterOperation, NGXFilterThisMonthOperation, NGXFilterThisWeekOperation, NGXFilterTodayOperation } from "./ngx-filters-operations"
+
+export class NGXFilterOperationFactory{
+
+    static create(filter: JSONRegularFilter): NGXFilterOperation{
+        if(filter.FieldType == "JsonBool" || filter.FieldType == "Guid"){
+            throw Error(`error in ngx filter operation factory, cannot convert filter with type ${filter.FieldType} to ngx lib smart filter`)
+        }
+        switch(filter.Operation){
+            case "IsEqual":
+            case "=": 
+                return new NGXFilterIsEqualOperation(filter)
+
+            case "!=":
+            case "IsNotEqual":
+                return new NGXFilterNotEqualOperation(filter)
+
+            case ">":
+                return new NGXFilterGreaterThanOperation(filter)
+
+            case "<":
+                return new NGXFilterLessThanOperation(filter)
+
+            case "Between":
+                return NGXFilterBetweenOperationFactory.create(filter)
+
+            case "Contains":
+                return new NGXFilterContainsOperation(filter)
+
+            case "StartWith":
+                return new NGXFilterBeginsWithOperation(filter)
+
+            case "EndWith":
+                return new NGXFilterEndsWithOperation(filter)
+
+            //dates:
+            case "InTheLast":
+                return new NGXFilterInTheLastOperation(filter)
+
+            case "DueIn":
+                return new NGXFilterDueInOperation(filter)
+            
+            case "NotDueIn":
+                return new NGXFilterNotDueInOperation(filter)
+
+            case "Today":
+                return new NGXFilterTodayOperation(filter)
+
+            case "ThisWeek":
+                return new NGXFilterThisWeekOperation(filter)
+
+            case "ThisMonth":
+                return new NGXFilterThisMonthOperation(filter)
+            
+            case "IsEmpty":
+                return new NGXFilterIsEmptyOperation(filter)
+
+            case "IsNotEmpty":
+                return new NGXFilterIsNotEmptyOperation(filter)
+
+            case "On":
+                return new NGXFilterOnOperation(filter)
+
+            default:
+                throw Error(`error: ${filter.Operation} is not supported!!`)
+        }
+    }
+}

--- a/ngx-filters/ngx-filters-operations.ts
+++ b/ngx-filters/ngx-filters-operations.ts
@@ -1,0 +1,278 @@
+import { JSONRegularFilter } from "../json-filter";
+import { IPepSmartFilterData, IPepSmartFilterDataValue, IPepSmartFilterOperator, IPepSmartFilterOperatorUnit, PepSmartFilterOperatorUnitType } from "./ngx-types";
+
+export abstract class NGXFilterOperation implements IPepSmartFilterData{
+    fieldId: string;
+    operator!: IPepSmartFilterOperator;
+    operatorUnit?: IPepSmartFilterOperatorUnit;
+    value: IPepSmartFilterDataValue;
+
+    constructor(filter: JSONRegularFilter){
+        this.fieldId = filter.ApiName
+        this.value = {first: null}
+    }
+}
+
+export class NGXFilterIsEqualOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['number', 'boolean', 'text'],
+            id: 'eq',
+            name: "EQUAL",
+            short: "="
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterNotEqualOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['number', 'text'],
+            id: 'neq',
+            name: "NOT_EQUAL",
+            short: "<>"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterLessThanOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['number'],
+            id: 'lt',
+            name: "LESS_THEN",
+            short: "<"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterGreaterThanOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['number'],
+            id: 'gt',
+            name: "GREATER_THEN",
+            short: ">"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterNumberRangeOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['number'],
+            id: 'numberRange',
+            name: "NUMBER_RANGE",
+            short: "Range"
+        }
+        this.value = {first: filter.Values[0], second: filter.Values[1]}
+    }
+}
+
+export class NGXFilterContainsOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['text'],
+            id: 'contains',
+            name: "CONTAINS",
+            short: "Contains"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterBeginsWithOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['text'],
+            id: 'beginsWith',
+            name: "BEGINS_WITH",
+            short: "Begins With"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterEndsWithOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['text'],
+            id: 'endsWith',
+            name: "ENDS_WITH",
+            short: "Ends With"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class  NGXFilterInTheLastOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        
+        this.operator = {
+            componentType: ['date'],
+            id: 'inTheLast',
+            name: "IN_THE_LAST",
+            short: "In the last"
+        }
+        this.operatorUnit = {
+            componentType: ['date'],
+            id: filter.Values[1].toLowerCase() as PepSmartFilterOperatorUnitType,
+            name: filter.Values[1].toUpperCase()
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterDateRangeOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "dateRange",
+            name: "DATE_RANGE",
+            short: "Range"
+        }
+        this.value = {first: filter.Values[0], second: filter.Values[1]}
+    }
+}
+
+export class NGXFilterTodayOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "today",
+            name: "TODAY",
+            short: "Today"
+        }
+    }
+}
+
+export class NGXFilterThisWeekOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "thisWeek",
+            name: "THIS_WEEK",
+            short: "This week"
+        }
+    }
+}
+
+export class NGXFilterThisMonthOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "thisMonth",
+            name: "THIS_MONTH",
+            short: "This month"
+        }
+    }
+}
+
+export class NGXFilterIsEmptyOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "isEmpty",
+            name: "IS_EMPTY",
+            short: "Is empty"
+        }
+    }
+}
+
+export class NGXFilterIsNotEmptyOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "isNotEmpty",
+            name: "IS_NOT_EMPTY",
+            short: "Is not empty"
+        }
+    }
+}
+
+export class NGXFilterOnOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "on",
+            name: "ON",
+            short: "On"
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+
+export class NGXFilterDueInOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "dueIn",
+            name: "DUE_IN",
+            short: "Due In"
+        }
+        this.operatorUnit = {
+            componentType: ['date'],
+            id: filter.Values[1].toLowerCase() as PepSmartFilterOperatorUnitType,
+            name: filter.Values[1].toUpperCase()
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterNotDueInOperation extends NGXFilterOperation{
+    constructor(filter: JSONRegularFilter){
+        super(filter)
+        this.operator = {
+            componentType: ['date'],
+            id: "notDueIn",
+            name: "NOT_DUE_IN",
+            short: "Not due In"
+        }
+        this.operatorUnit = {
+            componentType: ['date'],
+            id: filter.Values[1].toLowerCase() as PepSmartFilterOperatorUnitType,
+            name: filter.Values[1].toUpperCase()
+        }
+        this.value = {first: filter.Values[0]}
+    }
+}
+
+export class NGXFilterBetweenOperationFactory{
+
+    static create(filter: JSONRegularFilter){
+        if(filter.Operation != "Between"){
+            throw Error(`error in NGXFilterBetweenOperationFactory, operation of type ${filter.Operation} is not supported`)
+        }
+        switch(filter.FieldType){
+            case "Integer":
+            case "Double":
+                return new NGXFilterNumberRangeOperation(filter)
+            case "Date":
+                return new NGXFilterDateRangeOperation(filter)
+            default:
+                throw Error(`ngx filter between operation factory - ${filter.Operation} is not supported`)
+        }
+    }
+}

--- a/ngx-filters/ngx-types.d.ts
+++ b/ngx-filters/ngx-types.d.ts
@@ -1,0 +1,29 @@
+export interface IPepSmartFilterData {
+    fieldId: string;
+    operator: IPepSmartFilterOperator;
+    operatorUnit?: IPepSmartFilterOperatorUnit;
+    value: IPepSmartFilterDataValue;
+}
+
+export interface IPepSmartFilterDataValue {
+    first: any;
+    second?: any;
+}
+
+
+export declare class IPepSmartFilterOperator {
+    id: PepSmartFilterOperatorType;
+    name: string;
+    short: string;
+    componentType: PepSmartFilterComponentType[];
+}
+
+export declare class IPepSmartFilterOperatorUnit {
+    id: PepSmartFilterOperatorUnitType;
+    name: string;
+    componentType: PepSmartFilterComponentType[];
+}
+
+export declare type PepSmartFilterComponentType = 'text' | 'number' | 'date' | 'multi-select' | 'boolean';
+export declare type PepSmartFilterOperatorUnitType = 'days' | 'weeks' | 'months' | 'years';
+export declare type PepSmartFilterOperatorType = 'eq' | 'eqv' | 'neq' | 'neqv' | 'lt' | 'ltv' | 'gt' | 'gtv' | 'ltoe' | 'gtoe' | 'numberRange' | 'contains' | 'beginsWith' | 'endsWith' | 'after' | 'before' | 'inTheLast' | 'inTheLastCalendar' | 'today' | 'thisWeek' | 'thisMonth' | 'dateRange' | 'dateRangeVariable' | 'dueIn' | 'on' | 'notInTheLast' | 'notInTheLastCalendar' | 'notDueIn' | 'isEmpty' | 'isNotEmpty' | 'in';


### PR DESCRIPTION
The mapping between json filters and ngx smart filters is not one to one.
not all json filters can be mapped to ngx smart filters (for example JSONBool, Guid etc..)
therefore I didn't add toNgxSmartFilter method to the json filter object.